### PR TITLE
Make Theme Controls Modal use Elevation instead of Basic Drop Shadow

### DIFF
--- a/assets/css/custom/custom-components/theme-controls.css
+++ b/assets/css/custom/custom-components/theme-controls.css
@@ -11,7 +11,9 @@
     align-items: center;
     padding: var(--size-3);
   }
-
+  .controls::before {
+    box-shadow:none;
+  }
   .controls {
     position: absolute;
     inset: auto 0 auto auto;

--- a/assets/css/custom/custom-components/theme-controls.css
+++ b/assets/css/custom/custom-components/theme-controls.css
@@ -11,9 +11,11 @@
     align-items: center;
     padding: var(--size-3);
   }
+
   .controls::before {
     box-shadow:none;
   }
+  
   .controls {
     position: absolute;
     inset: auto 0 auto auto;

--- a/layouts/partials/theme-controls.html
+++ b/layouts/partials/theme-controls.html
@@ -10,7 +10,7 @@
     </i> 
   </label>
   
-  <div class="component sheet side modal controls">
+  <div class="component sheet side modal controls elevation1">
     <span class="theme-controls-title headline-medium">Theme controls</span>
     
     {{/*  Colors  */}}


### PR DESCRIPTION
Right now, differentiating the theme control modal from the rest of the page is quite difficult and requires one to strain their eyes quite a bit to do so. This PR simply removes the box shadow property from this element and replaces it with the Material elevation1 class, creating added consistency in the theme and a visual improvement. 

Here's an example of the difference:

| **Before:** | **After:**|
| ----------- | ---------
| ![image](https://github.com/user-attachments/assets/559894b3-b066-458d-b4ce-e7bef86bf0e1) | ![image](https://github.com/user-attachments/assets/0930e993-da1e-41f8-b7c4-69494fb0803d) |

I really love this Hugo theme though and can't wait to adapt to meet the needs of my next website!





